### PR TITLE
Fixed #241

### DIFF
--- a/tasks/css/easy/styles.css
+++ b/tasks/css/easy/styles.css
@@ -1,3 +1,4 @@
 /* CSS - Easy */
 
 /* TODO: Implement red-class */
+.red{ color: red}


### PR DESCRIPTION
Fixed #241
CSS-Easy
Change h1 to red in style.css
Changes made:

- in `tasks/css/easy/style.css` , I added the code by referencing the `h1` class which was set to `red`.

- I had to use `.red` to reference the red class instead of h1 , which would make ALL `h1` elements red which is not desirable.
