### PR TITLE
Fix Jest test scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "version": "1.1.3",
     "description": "Fork, Commit, Merge",
     "scripts": {
-        "test:medium": "jest tasks/javascript/medium",
-        "test:hard": "jest tasks/javascript/hard",
+        "test:medium": "jest tasks/javascript/jest/medium",
+        "test:hard": "jest tasks/javascript/jest/hard",
         "build": "tsc"
     },
     "devDependencies": {

--- a/tasks/javascript/jest/medium/tests/library.test.js
+++ b/tasks/javascript/jest/medium/tests/library.test.js
@@ -9,27 +9,27 @@ describe("Library", () => {
         library = new Library();
     });
 
-    test("createBook", () => {
+    it("createBook", () => {
         const newBook = library.createBook("Title 1", "Author 1");
-        expect(newBook.title).toBe("Title 2");
+        expect(newBook.title).toBe("Title 1");
     });
 
-    test("getBook", () => {
+    it("getBook", () => {
         library.createBook("Title 1", "Author 1");
         const book = library.getBook(1);
-        expect(book.title).toBe("Title 2");
+        expect(book.title).toBe("Title 1");
     });
 
-    test("updateBook", () => {
+    it("updateBook", () => {
         library.createBook("Title 1", "Author 1");
         const updatedBook = library.updateBook(1, "Title 2", "Author 2");
-        expect(updatedBook.title).toBe("Title 3");
+        expect(updatedBook.title).toBe("Title 2");
     });
 
-    test("deleteBook", () => {
+    it("deleteBook", () => {
         library.createBook("Title 1", "Author 1");
         const remainingBooks = library.deleteBook(2);
-        expect(remainingBooks.length).toBe(0);
+        expect(remainingBooks.length).toBe(1);
     });
 
 });


### PR DESCRIPTION
### Description

<!-- Please explain the changes you made here. -->

- Adjust test scripts that had the incorrect path
- Fixes the test scenarios in the `medium` folder

### Additional Context

<!-- This is optional, but provide any additional context about the changes here (such as screenshots). -->

First, run npm i in the root of the project to get all the necessary dependencies and execute `npm run test:medium`

#619
