### PR TITLE
README.md: added mojo installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ _Find awesome badges for your project in this repository: [markdown-badges](http
     -   [Installing Perl](#installing-perl)
     -   [Installing ASM (Assembly)](#installing-asm-assembly)
     -   [Installing Docker](#installing-docker)
+    -   [Installing Mojo](#installing-mojo)
 -   [Setup Instructions](#setup-instructions)
 -   [Tasks](#tasks)
 -   [Submitting Your Changes](#submitting-your-changes)
@@ -1454,6 +1455,29 @@ Remember to consult the official documentation for the most up-to-date and detai
 -   [Docker for Windows](https://docs.docker.com/desktop/install/windows-install/) installation guide
 -   [Docker for Mac](https://docs.docker.com/desktop/install/mac-install/) installation guide
 -   [Docker for Linux (Ubuntu/Debian)](https://docs.docker.com/engine/install/ubuntu/) installation guide
+
+### Installing Mojo
+
+#### macOS
+
+  - Install Brew by following this [guide](https://docs.brew.sh/Installation).
+  - Open a terminal and run the following commands:
+
+    ```bash
+    brew update
+    brew upgrade modular
+    modular install mojo
+    ```
+
+#### Linux (Ubuntu/Debian)
+
+To install Mojo on Linux (Ubuntu/Debian), you need to install Modular first. Follow these steps:
+
+```bash
+sudo apt update
+sudo apt install modular
+modular install mojo
+```
 
 ![line]
 


### PR DESCRIPTION
### Description

added mojo installation instruction mac and linux

### Additional Context

No support for Windows is available at the moment.
